### PR TITLE
Add MDX content build and GitHub Pages workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,38 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - run: npm install
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./dist
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-My personal blog
+# MDX Blog
+
+Place your `.mdx` files inside the `content/` folder. Running `npm run build` converts each file to an HTML page in `dist/` and creates an index page linking to them.
+
+Serve the generated site locally with:
+
+```bash
+npm run build
+npm run serve
+```
+
+A GitHub Actions workflow in `.github/workflows/deploy.yml` builds the site and publishes the `dist/` folder to GitHub Pages whenever you push to the `main` branch.

--- a/build.mjs
+++ b/build.mjs
@@ -1,0 +1,39 @@
+import esbuild from 'esbuild'
+import mdx from '@mdx-js/esbuild'
+import { promises as fs } from 'fs'
+import path from 'path'
+
+const contentDir = path.resolve('content')
+const distDir = path.resolve('dist')
+
+await fs.mkdir(distDir, { recursive: true })
+
+const files = (await fs.readdir(contentDir)).filter(f => f.endsWith('.mdx'))
+
+let links = ''
+for (const file of files) {
+  const name = path.parse(file).name
+  const tempEntry = path.join(distDir, `entry-${name}.tsx`)
+  const relativeMdxPath = path.relative(distDir, path.join(contentDir, file))
+  const entry = `import React from 'react';\nimport ReactDOM from 'react-dom/client';\nimport Content from './${relativeMdxPath.replace(/\\/g, '/') }';\nconst root = ReactDOM.createRoot(document.getElementById('root'));\nroot.render(<Content />);`
+  await fs.writeFile(tempEntry, entry)
+
+  await esbuild.build({
+    entryPoints: [tempEntry],
+    bundle: true,
+    minify: true,
+    outfile: path.join(distDir, `${name}.js`),
+    plugins: [mdx()],
+    write: true,
+  })
+
+  await fs.unlink(tempEntry)
+
+  const html = `<!DOCTYPE html>\n<html>\n<head>\n  <title>${name}</title>\n</head>\n<body>\n  <div id="root"></div>\n  <script src="${name}.js"></script>\n</body>\n</html>`
+  await fs.writeFile(path.join(distDir, `${name}.html`), html)
+  links += `  <li><a href="${name}.html">${name}</a></li>\n`
+}
+
+const indexHtml = `<!DOCTYPE html>\n<html>\n<head>\n  <title>Blog</title>\n</head>\n<body>\n  <h1>Blog Posts</h1>\n  <ul>\n${links.trim()}\n  </ul>\n</body>\n</html>`
+
+await fs.writeFile(path.join(distDir, 'index.html'), indexHtml)

--- a/content/example.mdx
+++ b/content/example.mdx
@@ -1,0 +1,1 @@
+# Example

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "serve" : "serve -s ./dist",
-    "build": "node esbuild.mjs"
+    "build": "node build.mjs"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- support building pages from `content/*.mdx`
- update npm build script to run new build file
- document how to build and serve the blog
- add example MDX file
- deploy `dist/` via GitHub Actions

## Testing
- `npm run build` *(fails: Cannot find package 'esbuild')*