### PR TITLE
Fix GitHub Pages output path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,13 +22,10 @@ jobs:
           npm install
           npm run build
 
-      - name: Ensure output directory exists
-        run: mkdir -p ./public
-
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./public
+          path: ./dist
           name: github-pages
 
   deploy:


### PR DESCRIPTION
## Summary
- fix GitHub Pages workflow so that dist directory is uploaded

## Testing
- `npm run build` *(fails: Cannot find package 'esbuild')*