### PR TITLE
Fix missing image on blog posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MDX Blog
 
-Place your `.mdx` files inside the `content/` folder. Running `npm run build` converts each file to an HTML page in `dist/` and creates an index page linking to them.
+Place your `.mdx` files inside the `content/` folder. Running `npm run build` converts each file to an HTML page in `dist/` and creates an index page linking to them. Any other files in `content/` (like images) are copied to `dist/` so you can reference them from your posts.
 
 Serve the generated site locally with:
 

--- a/build.mjs
+++ b/build.mjs
@@ -8,7 +8,11 @@ const distDir = path.resolve('dist')
 
 await fs.mkdir(distDir, { recursive: true })
 
-const files = (await fs.readdir(contentDir)).filter(f => f.endsWith('.mdx'))
+const entries = await fs.readdir(contentDir, { withFileTypes: true })
+const files = entries.filter(e => e.isFile() && e.name.endsWith('.mdx')).map(e => e.name)
+for (const asset of entries.filter(e => e.isFile() && !e.name.endsWith('.mdx'))) {
+  await fs.copyFile(path.join(contentDir, asset.name), path.join(distDir, asset.name))
+}
 
 let links = ''
 for (const file of files) {


### PR DESCRIPTION
## Summary
- copy non-MDX files from `content/` into `dist/` during build so images are published
- document copying of static assets in README

## Testing
- `npm run build` *(fails: Cannot find package 'esbuild')*