### PR TITLE
Center layout and style first paragraph

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -10,6 +10,8 @@ await fs.mkdir(distDir, { recursive: true })
 
 const files = (await fs.readdir(contentDir)).filter(f => f.endsWith('.mdx'))
 
+const style = `<style>\n  body { max-width: 800px; margin: 0 auto; }\n  p:first-of-type { color: gray; }\n</style>`
+
 let links = ''
 for (const file of files) {
   const name = path.parse(file).name
@@ -29,11 +31,11 @@ for (const file of files) {
 
   await fs.unlink(tempEntry)
 
-  const html = `<!DOCTYPE html>\n<html>\n<head>\n  <title>${name}</title>\n</head>\n<body>\n  <div id="root"></div>\n  <script src="${name}.js"></script>\n</body>\n</html>`
+  const html = `<!DOCTYPE html>\n<html>\n<head>\n  <title>${name}</title>\n  ${style}\n</head>\n<body>\n  <div id="root"></div>\n  <script src="${name}.js"></script>\n</body>\n</html>`
   await fs.writeFile(path.join(distDir, `${name}.html`), html)
   links += `  <li><a href="${name}.html">${name}</a></li>\n`
 }
 
-const indexHtml = `<!DOCTYPE html>\n<html>\n<head>\n  <title>Blog</title>\n</head>\n<body>\n  <h1>Blog Posts</h1>\n  <ul>\n${links.trim()}\n  </ul>\n</body>\n</html>`
+const indexHtml = `<!DOCTYPE html>\n<html>\n<head>\n  <title>Blog</title>\n  ${style}\n</head>\n<body>\n  <h1>Blog Posts</h1>\n  <ul>\n${links.trim()}\n  </ul>\n</body>\n</html>`
 
 await fs.writeFile(path.join(distDir, 'index.html'), indexHtml)

--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -2,6 +2,8 @@ import esbuild from 'esbuild';
 import mdx from "@mdx-js/esbuild"
 import fs from "fs"
 
+const style = `<style>\n  body { max-width: 800px; margin: 0 auto; }\n  p:first-of-type { color: gray; }\n</style>`
+
 esbuild
   .build({
     entryPoints: ['src/index.tsx'],
@@ -20,6 +22,7 @@ const html = `
 <html>
 <head>
   <title>My App</title>
+  ${style}
 </head>
 <body>
   <div id="root"/>


### PR DESCRIPTION
## Summary
- style the blog by injecting a stylesheet in the HTML templates
- color the first paragraph gray and keep the page centered

## Testing
- `npm run build` *(fails: Cannot find package 'esbuild')*